### PR TITLE
describe is allowed to be null

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target
 .classpath
 .project
 *.iml
+.idea

--- a/jgit-buildnumber-common/src/main/java/com/labun/buildnumber/BuildNumberExtractor.java
+++ b/jgit-buildnumber-common/src/main/java/com/labun/buildnumber/BuildNumberExtractor.java
@@ -135,7 +135,7 @@ public class BuildNumberExtractor {
                 params.getCountCommitsInPath());
             // don't use `headCommit`, `revWalk` from here on!
 
-            String describe = git.describe().setLong(true).call();
+            String describe = readDescribe(git);
 
             SimpleDateFormat dfBuildDate = new SimpleDateFormat(params.getBuildDateFormat());
             if (params.getDateFormatTimeZone() != null) dfBuildDate.setTimeZone(TimeZone.getTimeZone(params.getDateFormatTimeZone()));
@@ -220,6 +220,12 @@ public class BuildNumberExtractor {
         RevCommit[] parents = commit.getParents();
         if (parents == null || parents.length == 0) return EMPTY_STRING;
         return Stream.of(parents).map(p -> abbreviateSha1(p.getId().name()/*SHA-1*/, length)).collect(Collectors.joining(";"));
+    }
+
+    private static String readDescribe(Git git) throws Exception {
+       String describe = git.describe().setLong(true).call();
+        if (describe == null || describe.isEmpty()) return EMPTY_STRING;
+        return describe;
     }
 
     /** @return Map sha1 - tag names */

--- a/jgit-buildnumber-common/src/main/java/com/labun/buildnumber/BuildNumberExtractor.java
+++ b/jgit-buildnumber-common/src/main/java/com/labun/buildnumber/BuildNumberExtractor.java
@@ -223,7 +223,7 @@ public class BuildNumberExtractor {
     }
 
     private static String readDescribe(Git git) throws Exception {
-       String describe = git.describe().setLong(true).call();
+       String describe = git.describe().setLong(true).setAlways(true).call();
         if (describe == null || describe.isEmpty()) return EMPTY_STRING;
         return describe;
     }


### PR DESCRIPTION
The `git.describe` property (https://github.com/elab/jgit-buildnumber#extracted-properties) is the result of calling JGit `describe` command.

> If none of the ancestors of the commit being described has any tags at all, then this method returns null, indicating that there's no way to describe this tag.

[Javadoc of JGIT](http://download.eclipse.org/jgit/site/4.8.0.201706111038-r/apidocs/org/eclipse/jgit/api/DescribeCommand.html#call--)

This causes the plugin to fail, since all extracted properties are required to be not null.